### PR TITLE
fix(types): mark userHasPermissions as an arrow function explicitly

### DIFF
--- a/src/create.tsx
+++ b/src/create.tsx
@@ -17,10 +17,10 @@ export interface AbacProviderProps<
 }
 
 export interface AbacContextProps<Permission extends string> {
-    userHasPermissions<Data>(
+    userHasPermissions: <Data>(
         permissions: Permission | Permission[],
         data?: Data,
-    ): boolean;
+    ) => boolean;
 }
 
 export interface AllowedToProps<Permission extends string> {


### PR DESCRIPTION
Hello 👋 ,

When calling userHasPermissions with destructuring following the examples, it triggers an error when using [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/v5.7.0/packages/eslint-plugin/docs/rules/unbound-method.md).

Marking the method as an explicit arrow function ensures that it's not using "this" internally and solves the issue.